### PR TITLE
[Issue 12, US-005] View analysis details

### DIFF
--- a/nest-backend/src/scan/scan.controller.ts
+++ b/nest-backend/src/scan/scan.controller.ts
@@ -33,6 +33,20 @@ export class ScanController {
     return this.scanService.getUserScans(userId);
   }
 
+  @Get(':scanId')
+  @HttpCode(HttpStatus.OK)
+  async getScanById(@Param('scanId', ParseIntPipe) scanId: number) {
+    // TODO: Get userId from JWT token once authentication is implemented
+    const userId = 1;
+    const scan = await this.scanService.getScanById(scanId, userId);
+    
+    if (!scan) {
+      throw new NotFoundException('Scan not found or you do not have permission to view it');
+    }
+
+    return scan;
+  }
+
   @Delete(':scanId')
   @HttpCode(HttpStatus.OK)
   async deleteScan(@Param('scanId', ParseIntPipe) scanId: number) {

--- a/nest-backend/src/scan/scan.service.ts
+++ b/nest-backend/src/scan/scan.service.ts
@@ -57,6 +57,52 @@ export class ScanService {
     return scans;
   }
 
+  async getScanById(scanId: number, userId: number) {
+    const scan = await this.prisma.scan.findFirst({
+      where: {
+        id: scanId,
+        userId,
+      },
+      include: {
+        tags: true,
+      },
+    });
+
+    if (!scan) {
+      return null;
+    }
+
+    // Mock documents and AI detection results for now
+    // In a real implementation, these would come from related tables
+    const mockDocuments = [
+      {
+        id: 1,
+        name: `${scan.title} - Document 1`,
+        aiScore: 0.23,
+        classification: 'Human',
+        detectedBy: scan.aiProviders.length > 0 ? scan.aiProviders[0] : 'GPT-4',
+        content: scan.content || 'Sample content for analysis...',
+      },
+    ];
+
+    // If there are multiple AI providers, create results for each
+    if (scan.aiProviders.length > 1) {
+      mockDocuments.push({
+        id: 2,
+        name: `${scan.title} - Document 2`,
+        aiScore: 0.87,
+        classification: 'AI',
+        detectedBy: scan.aiProviders[1],
+        content: 'Another sample content analyzed by different AI provider...',
+      });
+    }
+
+    return {
+      ...scan,
+      documents: mockDocuments,
+    };
+  }
+
   async deleteScan(scanId: number, userId: number) {
     // Verify the scan belongs to the user
     const scan = await this.prisma.scan.findFirst({

--- a/react-frontend/src/App.jsx
+++ b/react-frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import Register from './pages/Register'
 import Login from './pages/Login'
 import Dashboard from './pages/Dashboard'
+import AnalysisDetail from './pages/AnalysisDetail'
 import ProtectedRoute from './components/ProtectedRoute'
 import PublicRoute from './components/PublicRoute'
 
@@ -22,6 +23,11 @@ function App () {
         <Route path="/logged-in" element={
           <ProtectedRoute>
             <Dashboard />
+          </ProtectedRoute>
+        } />
+        <Route path="/analysis/:id" element={
+          <ProtectedRoute>
+            <AnalysisDetail />
           </ProtectedRoute>
         } />
         <Route path="/" element={

--- a/react-frontend/src/pages/AnalysisDetail.jsx
+++ b/react-frontend/src/pages/AnalysisDetail.jsx
@@ -1,0 +1,293 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Icon } from '@iconify/react';
+import Toastify from 'toastify-js';
+import 'toastify-js/src/toastify.css';
+import useAuthStore from '../store/authStore';
+
+function AnalysisDetail() {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const user = useAuthStore((state) => state.user);
+
+  const [analysis, setAnalysis] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!accessToken) {
+      navigate('/login');
+      return;
+    }
+
+    const fetchAnalysis = async () => {
+      try {
+        setLoading(true);
+        const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3333';
+        const response = await fetch(`${apiUrl}/api/v1/scan/${id}`, {
+          headers: {
+            'Authorization': `Bearer ${accessToken}`,
+          },
+        });
+
+        if (!response.ok) {
+          throw new Error('Failed to fetch analysis details');
+        }
+
+        const data = await response.json();
+        setAnalysis(data);
+      } catch (err) {
+        setError(err.message);
+        Toastify({
+          text: 'Failed to load analysis details',
+          duration: 3000,
+          gravity: 'top',
+          position: 'right',
+          style: {
+            background: 'linear-gradient(to right, #ff5f6d, #ffc371)',
+          },
+        }).showToast();
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchAnalysis();
+  }, [id, accessToken, navigate]);
+
+  const handleBack = () => {
+    navigate('/logged-in');
+  };
+
+  const formatDate = (date) => {
+    return new Date(date).toLocaleDateString('en-US', { 
+      month: 'short', 
+      day: 'numeric', 
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  };
+
+  const getScoreColor = (score) => {
+    if (score < 0.3) return 'text-green-600';
+    if (score < 0.7) return 'text-yellow-600';
+    return 'text-red-600';
+  };
+
+  const getScoreBgColor = (score) => {
+    if (score < 0.3) return 'bg-green-100';
+    if (score < 0.7) return 'bg-yellow-100';
+    return 'bg-red-100';
+  };
+
+  const getScoreBarColor = (score) => {
+    if (score < 0.3) return 'bg-gradient-to-r from-green-500 to-emerald-400';
+    if (score < 0.7) return 'bg-gradient-to-r from-yellow-500 to-amber-400';
+    return 'bg-gradient-to-r from-red-500 to-rose-400';
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-gray-50">
+        <div className="text-center">
+          <Icon icon="mdi:loading" className="animate-spin text-4xl text-[#2563EB] mx-auto mb-4" />
+          <p className="text-gray-600">Loading analysis details...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !analysis) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-gray-50">
+        <div className="text-center">
+          <Icon icon="mdi:alert-circle" className="text-6xl text-red-500 mx-auto mb-4" />
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">Analysis Not Found</h2>
+          <p className="text-gray-600 mb-6">{error || 'The analysis you are looking for does not exist.'}</p>
+          <button
+            onClick={handleBack}
+            className="inline-flex items-center gap-2 px-6 py-3 bg-[#2563EB] text-white rounded-lg font-bold hover:bg-blue-700 transition-colors"
+          >
+            <Icon icon="mdi:arrow-left" className="text-xl" />
+            Back to Dashboard
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <header className="bg-[#1E40AF] shadow-sm">
+        <div className="px-6 lg:px-10 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4 text-white">
+              <div className="flex items-center justify-center">
+                <Icon icon="mdi:radar" className="text-2xl" />
+              </div>
+              <h2 className="text-xl font-bold">AI Detector</h2>
+            </div>
+            <div className="flex items-center gap-4">
+              <div className="flex items-center gap-2 bg-white/10 px-3 py-2 rounded-lg">
+                <Icon icon="mdi:account-circle" className="text-xl text-white" />
+                <span className="text-sm font-medium text-white hidden sm:inline">{user?.username}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      {/* Main Content */}
+      <main className="px-6 lg:px-20 py-8">
+        <div className="max-w-7xl mx-auto space-y-6">
+          {/* Back Button */}
+          <button
+            onClick={handleBack}
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            <Icon icon="mdi:arrow-left" className="text-lg" />
+            Back to Dashboard
+          </button>
+
+          {/* Analysis Header */}
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-6">
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+              <div className="flex-1">
+                <h1 className="text-3xl font-bold text-gray-900 mb-2">{analysis.title}</h1>
+                <div className="flex flex-wrap gap-4 text-sm text-gray-600">
+                  <div className="flex items-center gap-1">
+                    <Icon icon="mdi:calendar" className="text-lg" />
+                    <span>{formatDate(analysis.createdAt)}</span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Icon icon="mdi:file-document-multiple" className="text-lg" />
+                    <span>{analysis.documents?.length || 0} Document{analysis.documents?.length !== 1 ? 's' : ''}</span>
+                  </div>
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {analysis.tags?.map((tag) => (
+                  <span
+                    key={tag.id}
+                    className="px-3 py-1 inline-flex text-sm font-semibold rounded-full bg-blue-100 text-blue-800 border border-blue-200"
+                  >
+                    {tag.name}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* AI Providers Used */}
+          {analysis.aiProviders && analysis.aiProviders.length > 0 && (
+            <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-6">
+              <h2 className="text-lg font-bold text-gray-900 mb-4 flex items-center gap-2">
+                <Icon icon="mdi:robot" className="text-xl" />
+                AI Detection Models Used
+              </h2>
+              <div className="flex flex-wrap gap-2">
+                {analysis.aiProviders.map((provider, index) => (
+                  <span
+                    key={index}
+                    className="px-4 py-2 inline-flex items-center gap-2 text-sm font-medium rounded-lg bg-purple-100 text-purple-800 border border-purple-200"
+                  >
+                    <span className="size-2 rounded-full bg-purple-500"></span>
+                    {provider}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Documents Analysis Results */}
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-6">
+            <h2 className="text-lg font-bold text-gray-900 mb-6 flex items-center gap-2">
+              <Icon icon="mdi:chart-bar" className="text-xl" />
+              Document Analysis Results
+            </h2>
+
+            <div className="space-y-6">
+              {analysis.documents?.map((document) => (
+                <div
+                  key={document.id}
+                  className="border border-gray-200 rounded-lg p-6 hover:shadow-md transition-shadow"
+                >
+                  {/* Document Header */}
+                  <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4 mb-4">
+                    <div className="flex-1">
+                      <h3 className="text-lg font-bold text-gray-900 mb-1">{document.name}</h3>
+                      <p className="text-sm text-gray-600">
+                        Analyzed by: <span className="font-medium text-gray-900">{document.detectedBy}</span>
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      {document.classification === 'Human' ? (
+                        <div className="flex items-center gap-2 px-4 py-2 bg-green-100 text-green-800 border border-green-200 rounded-lg">
+                          <Icon icon="mdi:check-circle" className="text-xl" />
+                          <span className="font-bold">Human Written</span>
+                        </div>
+                      ) : (
+                        <div className="flex items-center gap-2 px-4 py-2 bg-red-100 text-red-800 border border-red-200 rounded-lg">
+                          <Icon icon="mdi:alert-circle" className="text-xl" />
+                          <span className="font-bold">AI Generated</span>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* AI Detection Score */}
+                  <div className="mb-4">
+                    <div className="flex items-center justify-between mb-2">
+                      <span className="text-sm font-semibold text-gray-700">AI Detection Score</span>
+                      <span className={`text-2xl font-bold ${getScoreColor(document.aiScore)}`}>
+                        {(document.aiScore * 100).toFixed(1)}%
+                      </span>
+                    </div>
+                    <div className="w-full bg-gray-100 rounded-full h-4 overflow-hidden">
+                      <div
+                        className={`h-4 rounded-full ${getScoreBarColor(document.aiScore)}`}
+                        style={{ width: `${document.aiScore * 100}%` }}
+                      ></div>
+                    </div>
+                    <div className="flex justify-between mt-2 text-xs text-gray-500">
+                      <span>0% (Human)</span>
+                      <span>50%</span>
+                      <span>100% (AI)</span>
+                    </div>
+                  </div>
+
+                  {/* Document Content Preview */}
+                  <div className="bg-gray-50 rounded-lg p-4 border border-gray-200">
+                    <p className="text-sm font-semibold text-gray-700 mb-2">Content Preview:</p>
+                    <p className="text-sm text-gray-600 line-clamp-3">{document.content}</p>
+                  </div>
+
+                  {/* Score Interpretation */}
+                  <div className={`mt-4 p-4 rounded-lg border ${getScoreBgColor(document.aiScore)} ${document.aiScore < 0.3 ? 'border-green-200' : document.aiScore < 0.7 ? 'border-yellow-200' : 'border-red-200'}`}>
+                    <p className="text-sm font-medium text-gray-900">
+                      {document.aiScore < 0.3 && '✓ Low probability of AI generation. Content appears to be human-written.'}
+                      {document.aiScore >= 0.3 && document.aiScore < 0.7 && '⚠ Moderate probability of AI generation. Content may be mixed or edited.'}
+                      {document.aiScore >= 0.7 && '⚠ High probability of AI generation. Content likely produced by AI.'}
+                    </p>
+                  </div>
+                </div>
+              ))}
+
+              {(!analysis.documents || analysis.documents.length === 0) && (
+                <div className="text-center py-12">
+                  <Icon icon="mdi:file-document-outline" className="text-6xl text-gray-300 mx-auto mb-4" />
+                  <p className="text-gray-600">No documents found for this analysis.</p>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export default AnalysisDetail;

--- a/react-frontend/src/pages/Dashboard.jsx
+++ b/react-frontend/src/pages/Dashboard.jsx
@@ -321,7 +321,10 @@ function Dashboard() {
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                           <div className="flex justify-end gap-3">
-                            <button className="text-gray-400 hover:text-[#6324eb] transition-colors">
+                            <button 
+                              onClick={() => navigate(`/analysis/${scan.id}`)}
+                              className="text-gray-400 hover:text-[#6324eb] transition-colors"
+                            >
                               <Icon icon="mdi:eye" className="text-xl" />
                             </button>
                             <button

--- a/react-frontend/src/tests/AnalysisDetail.test.jsx
+++ b/react-frontend/src/tests/AnalysisDetail.test.jsx
@@ -1,0 +1,319 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import AnalysisDetail from '../pages/AnalysisDetail';
+import useAuthStore from '../store/authStore';
+
+// Mock useNavigate and useParams
+const mockNavigate = vi.fn();
+const mockParams = { id: '1' };
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => mockParams,
+  };
+});
+
+// Mock Toastify
+const mockShowToast = vi.fn();
+vi.mock('toastify-js', () => ({
+  default: vi.fn(() => ({
+    showToast: mockShowToast,
+  })),
+}));
+
+// Mock @iconify/react
+vi.mock('@iconify/react', () => ({
+  Icon: ({ icon }) => <span data-testid="icon" data-icon={icon}></span>,
+}));
+
+// Mock fetch
+global.fetch = vi.fn();
+
+describe('AnalysisDetail Component - US-005', () => {
+  const mockUser = {
+    id: 1,
+    email: 'test@example.com',
+    username: 'testuser',
+    createdAt: new Date('2024-01-01').toISOString(),
+  };
+
+  const mockAnalysis = {
+    id: 1,
+    title: 'Student Essay Batch #42',
+    content: 'Sample essay content for analysis...',
+    aiProviders: ['GPT-4', 'Llama'],
+    userId: 1,
+    createdAt: '2023-10-23T14:15:00.000Z',
+    updatedAt: '2023-10-23T14:15:00.000Z',
+    tags: [
+      { id: 1, name: 'Academic' },
+      { id: 2, name: 'High Risk' },
+    ],
+    documents: [
+      {
+        id: 1,
+        name: 'Student Essay Batch #42 - Document 1',
+        aiScore: 0.23,
+        classification: 'Human',
+        detectedBy: 'GPT-4',
+        content: 'Sample content for analysis...',
+      },
+      {
+        id: 2,
+        name: 'Student Essay Batch #42 - Document 2',
+        aiScore: 0.87,
+        classification: 'AI',
+        detectedBy: 'Llama',
+        content: 'Another sample content analyzed by different AI provider...',
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthStore.getState().clearAuth();
+    global.fetch.mockClear();
+  });
+
+  afterEach(() => {
+    useAuthStore.getState().clearAuth();
+    cleanup();
+  });
+
+  const renderAnalysisDetail = () => {
+    return render(
+      <BrowserRouter>
+        <Routes>
+          <Route path="*" element={<AnalysisDetail />} />
+        </Routes>
+      </BrowserRouter>
+    );
+  };
+
+  it('should redirect to login when not authenticated', () => {
+    renderAnalysisDetail();
+    expect(mockNavigate).toHaveBeenCalledWith('/login');
+  });
+
+  it('should display loading state initially', () => {
+    useAuthStore.getState().setAuth(mockUser, {
+      accessToken: 'test-token',
+      refreshToken: 'test-refresh-token',
+    });
+
+    global.fetch.mockImplementation(() => new Promise(() => {})); // Never resolves
+
+    renderAnalysisDetail();
+
+    expect(screen.getByText('Loading analysis details...')).toBeInTheDocument();
+  });
+
+  it('should fetch and display analysis details with relations', async () => {
+    useAuthStore.getState().setAuth(mockUser, {
+      accessToken: 'test-token',
+      refreshToken: 'test-refresh-token',
+    });
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockAnalysis,
+    });
+
+    renderAnalysisDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText('Student Essay Batch #42')).toBeInTheDocument();
+    });
+
+    // Check analysis metadata
+    expect(screen.getByText('2 Documents')).toBeInTheDocument();
+    
+    // Check tags
+    expect(screen.getByText('Academic')).toBeInTheDocument();
+    expect(screen.getByText('High Risk')).toBeInTheDocument();
+
+    // Check AI providers - use getAllByText since they appear multiple times
+    const gpt4Elements = screen.getAllByText('GPT-4');
+    expect(gpt4Elements.length).toBeGreaterThan(0);
+    const llamaElements = screen.getAllByText('Llama');
+    expect(llamaElements.length).toBeGreaterThan(0);
+  });
+
+  it('should display document results with AI detection scores', async () => {
+    useAuthStore.getState().setAuth(mockUser, {
+      accessToken: 'test-token',
+      refreshToken: 'test-refresh-token',
+    });
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockAnalysis,
+    });
+
+    renderAnalysisDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText('Student Essay Batch #42 - Document 1')).toBeInTheDocument();
+    });
+
+    // Check document 1 (Human)
+    expect(screen.getByText('Human Written')).toBeInTheDocument();
+    expect(screen.getByText('23.0%')).toBeInTheDocument();
+
+    // Check document 2 (AI)
+    expect(screen.getByText('AI Generated')).toBeInTheDocument();
+    expect(screen.getByText('87.0%')).toBeInTheDocument();
+  });
+
+  it('should display AI vs Human classification clearly', async () => {
+    useAuthStore.getState().setAuth(mockUser, {
+      accessToken: 'test-token',
+      refreshToken: 'test-refresh-token',
+    });
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockAnalysis,
+    });
+
+    renderAnalysisDetail();
+
+    await waitFor(() => {
+      // Check for classification icons
+      const icons = screen.getAllByTestId('icon');
+      const checkIcon = icons.find(icon => icon.getAttribute('data-icon') === 'mdi:check-circle');
+      const alertIcon = icons.find(icon => icon.getAttribute('data-icon') === 'mdi:alert-circle');
+      
+      expect(checkIcon).toBeInTheDocument();
+      expect(alertIcon).toBeInTheDocument();
+    });
+  });
+
+  it('should have back button that navigates to dashboard', async () => {
+    useAuthStore.getState().setAuth(mockUser, {
+      accessToken: 'test-token',
+      refreshToken: 'test-refresh-token',
+    });
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockAnalysis,
+    });
+
+    renderAnalysisDetail();
+
+    await waitFor(() => {
+      const backButtons = screen.getAllByText('Back to Dashboard');
+      expect(backButtons.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('should display error message when analysis not found', async () => {
+    useAuthStore.getState().setAuth(mockUser, {
+      accessToken: 'test-token',
+      refreshToken: 'test-refresh-token',
+    });
+
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    });
+
+    renderAnalysisDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText('Analysis Not Found')).toBeInTheDocument();
+    });
+  });
+
+  it('should use correct API endpoint with authentication', async () => {
+    useAuthStore.getState().setAuth(mockUser, {
+      accessToken: 'test-token',
+      refreshToken: 'test-refresh-token',
+    });
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockAnalysis,
+    });
+
+    renderAnalysisDetail();
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v1/scan/1'),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'Authorization': 'Bearer test-token',
+          }),
+        })
+      );
+    });
+  });
+
+  it('should display all document information including AI model used', async () => {
+    useAuthStore.getState().setAuth(mockUser, {
+      accessToken: 'test-token',
+      refreshToken: 'test-refresh-token',
+    });
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockAnalysis,
+    });
+
+    renderAnalysisDetail();
+
+    await waitFor(() => {
+      // Check that each document shows which model analyzed it
+      const analyzedByElements = screen.getAllByText(/Analyzed by:/);
+      expect(analyzedByElements.length).toBeGreaterThan(0);
+      expect(screen.getByText('Student Essay Batch #42 - Document 1')).toBeInTheDocument();
+      expect(screen.getByText('Student Essay Batch #42 - Document 2')).toBeInTheDocument();
+    });
+  });
+
+  it('should display score visualization bars', async () => {
+    useAuthStore.getState().setAuth(mockUser, {
+      accessToken: 'test-token',
+      refreshToken: 'test-refresh-token',
+    });
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockAnalysis,
+    });
+
+    renderAnalysisDetail();
+
+    await waitFor(() => {
+      // Check for chart-bar icon
+      const icons = screen.getAllByTestId('icon');
+      const chartIcon = icons.find(icon => icon.getAttribute('data-icon') === 'mdi:chart-bar');
+      expect(chartIcon).toBeInTheDocument();
+    });
+  });
+
+  it('should show content preview for each document', async () => {
+    useAuthStore.getState().setAuth(mockUser, {
+      accessToken: 'test-token',
+      refreshToken: 'test-refresh-token',
+    });
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockAnalysis,
+    });
+
+    renderAnalysisDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText('Sample content for analysis...')).toBeInTheDocument();
+      expect(screen.getByText('Another sample content analyzed by different AI provider...')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces a new "Analysis Detail" feature, allowing users to view detailed information about a specific scan/analysis, including document-level AI detection results, tags, and AI providers. It includes backend API additions, frontend routing and UI, and comprehensive tests to ensure correct functionality and display.

**Backend API enhancements:**

* Added a new endpoint in `ScanController` to fetch a scan by its ID, with user permission checks and proper error handling.
* Implemented `getScanById` in `ScanService`, returning scan details, tags, AI providers, and mock document analysis results for each document.

**Frontend feature implementation:**

* Created the `AnalysisDetail` page component to display scan metadata, tags, AI providers, document results with AI detection scores, classification, model used, and content preview, including score visualization and interpretation.
* Added routing for `/analysis/:id` and navigation from the dashboard to the detail page. [[1]](diffhunk://#diff-ea9d50fec39076159859e098533669812d373615628faefdccaf1fc70366b358R5) [[2]](diffhunk://#diff-ea9d50fec39076159859e098533669812d373615628faefdccaf1fc70366b358R28-R32) [[3]](diffhunk://#diff-bb762301ac761a72305442eb8f399077dd8d2289c6467de506ef8f63bb0882acL324-R327)

**Testing improvements:**

* Added a comprehensive test suite for `AnalysisDetail`, covering authentication, loading/error states, API calls, UI rendering of all relevant details, and user navigation.

Closes #12 