### PR TITLE
[Issue 17, US-010] Create new analysis

### DIFF
--- a/nest-backend/package.json
+++ b/nest-backend/package.json
@@ -53,6 +53,7 @@
     "@types/bcrypt": "^6.0.0",
     "@types/express": "^5.0.0",
     "@types/jest": "^30.0.0",
+    "@types/multer": "^2.0.0",
     "@types/node": "^22.10.7",
     "@types/passport-jwt": "^4.0.1",
     "@types/supertest": "^6.0.2",

--- a/nest-backend/pnpm-lock.yaml
+++ b/nest-backend/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
+      '@types/multer':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@types/node':
         specifier: ^22.10.7
         version: 22.19.7
@@ -1072,6 +1075,9 @@ packages:
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/multer@2.0.0':
+    resolution: {integrity: sha512-C3Z9v9Evij2yST3RSBktxP9STm6OdMc5uR1xF1SGr98uv8dUlAL2hqwrZ3GVB3uyMyiegnscEK6PGtYvNrjTjw==}
 
   '@types/node@22.19.7':
     resolution: {integrity: sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==}
@@ -4813,6 +4819,10 @@ snapshots:
   '@types/methods@1.1.4': {}
 
   '@types/ms@2.1.0': {}
+
+  '@types/multer@2.0.0':
+    dependencies:
+      '@types/express': 5.0.6
 
   '@types/node@22.19.7':
     dependencies:

--- a/nest-backend/prisma/migrations/20260211222347_add_documents_table/migration.sql
+++ b/nest-backend/prisma/migrations/20260211222347_add_documents_table/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "Document" (
+    "id" SERIAL NOT NULL,
+    "filename" TEXT NOT NULL,
+    "originalName" TEXT NOT NULL,
+    "mimetype" TEXT NOT NULL,
+    "size" INTEGER NOT NULL,
+    "path" TEXT NOT NULL,
+    "scanId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Document_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Document" ADD CONSTRAINT "Document_scanId_fkey" FOREIGN KEY ("scanId") REFERENCES "Scan"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/nest-backend/prisma/schema.prisma
+++ b/nest-backend/prisma/schema.prisma
@@ -18,15 +18,28 @@ model User {
 }
 
 model Scan {
-  id          Int       @id @default(autoincrement())
+  id          Int        @id @default(autoincrement())
   title       String
-  content     String?   @db.Text
+  content     String?    @db.Text
   aiProviders String[]
   userId      Int
-  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user        User       @relation(fields: [userId], references: [id], onDelete: Cascade)
   tags        Tag[]
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  documents   Document[]
+  createdAt   DateTime   @default(now())
+  updatedAt   DateTime   @updatedAt
+}
+
+model Document {
+  id           Int      @id @default(autoincrement())
+  filename     String
+  originalName String
+  mimetype     String
+  size         Int
+  path         String
+  scanId       Int
+  scan         Scan     @relation(fields: [scanId], references: [id], onDelete: Cascade)
+  createdAt    DateTime @default(now())
 }
 
 model Tag {

--- a/nest-backend/src/scan/dto/create-scan.dto.ts
+++ b/nest-backend/src/scan/dto/create-scan.dto.ts
@@ -19,3 +19,19 @@ export class CreateScanDto {
   @IsOptional()
   tags?: string[];
 }
+
+export class CreateScanWithFilesDto {
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  aiProviders?: string[];
+
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  tags?: string[];
+}

--- a/nest-backend/src/scan/scan.controller.ts
+++ b/nest-backend/src/scan/scan.controller.ts
@@ -10,9 +10,15 @@ import {
   ValidationPipe,
   ParseIntPipe,
   NotFoundException,
+  UseInterceptors,
+  UploadedFiles,
+  BadRequestException,
 } from '@nestjs/common';
+import { FilesInterceptor } from '@nestjs/platform-express';
+import { diskStorage } from 'multer';
+import { extname } from 'path';
 import { ScanService } from './scan.service';
-import { CreateScanDto } from './dto/create-scan.dto';
+import { CreateScanDto, CreateScanWithFilesDto } from './dto/create-scan.dto';
 
 @Controller('api/v1/scan')
 export class ScanController {
@@ -25,6 +31,64 @@ export class ScanController {
     // For now, we'll use a default userId
     const userId = 1;
     return this.scanService.createScan(userId, createScanDto);
+  }
+
+  @Post('with-files')
+  @HttpCode(HttpStatus.CREATED)
+  @UseInterceptors(
+    FilesInterceptor('documents', 10, {
+      storage: diskStorage({
+        destination: './uploads',
+        filename: (req, file, cb) => {
+          const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1e9);
+          cb(null, `${uniqueSuffix}${extname(file.originalname)}`);
+        },
+      }),
+      fileFilter: (req, file, cb) => {
+        const allowedMimeTypes = [
+          'application/pdf',
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+          'text/plain',
+        ];
+        if (allowedMimeTypes.includes(file.mimetype)) {
+          cb(null, true);
+        } else {
+          cb(
+            new BadRequestException(
+              'Invalid file type. Only PDF, DOCX, and TXT files are allowed.',
+            ),
+            false,
+          );
+        }
+      },
+      limits: {
+        fileSize: 10 * 1024 * 1024, // 10MB
+      },
+    }),
+  )
+  async createScanWithFiles(
+    @Body() body: any,
+    @UploadedFiles() files: Express.Multer.File[],
+  ) {
+    if (!files || files.length === 0) {
+      throw new BadRequestException('At least one document is required');
+    }
+
+    // Parse JSON fields from form-data
+    const createScanDto: CreateScanWithFilesDto = {
+      title: body.title,
+      aiProviders: body.aiProviders ? JSON.parse(body.aiProviders) : [],
+      tags: body.tags ? JSON.parse(body.tags) : [],
+    };
+
+    // Validate DTO
+    if (!createScanDto.title || createScanDto.title.trim() === '') {
+      throw new BadRequestException('Title is required');
+    }
+
+    // TODO: Get userId from JWT token once authentication is implemented
+    const userId = 1;
+    return this.scanService.createScanWithFiles(userId, createScanDto, files);
   }
 
   @Get('user/:userId')

--- a/nest-backend/src/scan/scan.service.spec.ts
+++ b/nest-backend/src/scan/scan.service.spec.ts
@@ -148,6 +148,7 @@ describe('ScanService', () => {
         },
         include: {
           tags: true,
+          documents: true,
         },
         orderBy: {
           createdAt: 'desc',

--- a/nest-backend/src/scan/scan.service.ts
+++ b/nest-backend/src/scan/scan.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
-import { CreateScanDto } from './dto/create-scan.dto';
+import { CreateScanDto, CreateScanWithFilesDto } from './dto/create-scan.dto';
 
 @Injectable()
 export class ScanService {
@@ -41,6 +41,54 @@ export class ScanService {
     return scan;
   }
 
+  async createScanWithFiles(
+    userId: number,
+    createScanDto: CreateScanWithFilesDto,
+    files: Express.Multer.File[],
+  ) {
+    const { title, aiProviders, tags } = createScanDto;
+
+    // First, get or create tags
+    const tagObjects = tags
+      ? await Promise.all(
+          tags.map(async (tagName) => {
+            return this.prisma.tag.upsert({
+              where: { name: tagName },
+              update: {},
+              create: { name: tagName },
+            });
+          }),
+        )
+      : [];
+
+    // Create the scan with tags and documents
+    const scan = await this.prisma.scan.create({
+      data: {
+        title,
+        aiProviders: aiProviders || [],
+        userId,
+        tags: {
+          connect: tagObjects.map((tag) => ({ id: tag.id })),
+        },
+        documents: {
+          create: files.map((file) => ({
+            filename: file.filename,
+            originalName: file.originalname,
+            mimetype: file.mimetype,
+            size: file.size,
+            path: file.path,
+          })),
+        },
+      },
+      include: {
+        tags: true,
+        documents: true,
+      },
+    });
+
+    return scan;
+  }
+
   async getUserScans(userId: number) {
     const scans = await this.prisma.scan.findMany({
       where: {
@@ -48,6 +96,7 @@ export class ScanService {
       },
       include: {
         tags: true,
+        documents: true,
       },
       orderBy: {
         createdAt: 'desc',

--- a/react-frontend/src/components/CreateScanModal.jsx
+++ b/react-frontend/src/components/CreateScanModal.jsx
@@ -1,0 +1,481 @@
+import { useState, useRef, useEffect } from 'react';
+import { Icon } from '@iconify/react';
+import * as Yup from 'yup';
+import Toastify from 'toastify-js';
+import 'toastify-js/src/toastify.css';
+
+// Validation schema using Yup
+const scanValidationSchema = Yup.object().shape({
+  title: Yup.string()
+    .required('Scan title is required')
+    .min(3, 'Title must be at least 3 characters')
+    .max(100, 'Title must be less than 100 characters'),
+  aiProviders: Yup.array()
+    .of(Yup.string())
+    .min(0, 'Select at least one AI provider'),
+  tags: Yup.array()
+    .of(Yup.string())
+    .min(0, 'Add at least one tag'),
+  documents: Yup.array()
+    .min(1, 'At least one document is required')
+    .test('fileSize', 'Each file must be less than 10MB', (files) => {
+      if (!files) return false;
+      return files.every((file) => file.size <= 10 * 1024 * 1024);
+    })
+    .test('fileType', 'Only PDF, DOCX, and TXT files are allowed', (files) => {
+      if (!files) return false;
+      const allowedTypes = [
+        'application/pdf',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'text/plain',
+      ];
+      return files.every((file) => allowedTypes.includes(file.type));
+    }),
+});
+
+// Available AI providers
+const AI_PROVIDERS = [
+  { id: 'gpt-4', name: 'GPT-4', color: 'purple' },
+  { id: 'claude', name: 'Claude', color: 'orange' },
+  { id: 'llama', name: 'Llama', color: 'green' },
+  { id: 'gemini', name: 'Gemini', color: 'blue' },
+];
+
+// Available tags
+const AVAILABLE_TAGS = [
+  { id: 'academic', name: 'Academic', color: 'blue' },
+  { id: 'marketing', name: 'Marketing', color: 'gray' },
+  { id: 'internal', name: 'Internal', color: 'gray' },
+  { id: 'high-risk', name: 'High Risk', color: 'red' },
+  { id: 'verified-human', name: 'Verified Human', color: 'teal' },
+];
+
+function CreateScanModal({ isOpen, onClose, onScanCreated }) {
+  const [formData, setFormData] = useState({
+    title: '',
+    aiProviders: [],
+    tags: [],
+    documents: [],
+  });
+  const [errors, setErrors] = useState({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef(null);
+
+  // Reset form when modal opens/closes
+  useEffect(() => {
+    if (!isOpen) {
+      setFormData({
+        title: '',
+        aiProviders: [],
+        tags: [],
+        documents: [],
+      });
+      setErrors({});
+      setIsDragging(false);
+    }
+  }, [isOpen]);
+
+  // Handle escape key
+  useEffect(() => {
+    const handleEscape = (event) => {
+      if (event.key === 'Escape' && isOpen && !isSubmitting) {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape);
+      document.body.style.overflow = 'hidden';
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen, isSubmitting, onClose]);
+
+  const handleFileSelect = (event) => {
+    const selectedFiles = Array.from(event.target.files || []);
+    if (selectedFiles.length > 0) {
+      setFormData((prev) => ({
+        ...prev,
+        documents: [...prev.documents, ...selectedFiles],
+      }));
+      setErrors((prev) => ({ ...prev, documents: '' }));
+    }
+  };
+
+  const handleDragOver = (event) => {
+    event.preventDefault();
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (event) => {
+    event.preventDefault();
+    setIsDragging(false);
+  };
+
+  const handleDrop = (event) => {
+    event.preventDefault();
+    setIsDragging(false);
+    const droppedFiles = Array.from(event.dataTransfer.files || []);
+    if (droppedFiles.length > 0) {
+      setFormData((prev) => ({
+        ...prev,
+        documents: [...prev.documents, ...droppedFiles],
+      }));
+      setErrors((prev) => ({ ...prev, documents: '' }));
+    }
+  };
+
+  const handleRemoveFile = (index) => {
+    setFormData((prev) => ({
+      ...prev,
+      documents: prev.documents.filter((_, i) => i !== index),
+    }));
+  };
+
+  const toggleAIProvider = (providerId) => {
+    setFormData((prev) => ({
+      ...prev,
+      aiProviders: prev.aiProviders.includes(providerId)
+        ? prev.aiProviders.filter((id) => id !== providerId)
+        : [...prev.aiProviders, providerId],
+    }));
+  };
+
+  const toggleTag = (tagId) => {
+    setFormData((prev) => ({
+      ...prev,
+      tags: prev.tags.includes(tagId)
+        ? prev.tags.filter((id) => id !== tagId)
+        : [...prev.tags, tagId],
+    }));
+  };
+
+  const getFileIcon = (file) => {
+    if (file.type === 'application/pdf') {
+      return { icon: 'mdi:file-pdf', color: 'text-red-500' };
+    } else if (
+      file.type ===
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+    ) {
+      return { icon: 'mdi:file-word', color: 'text-blue-500' };
+    } else {
+      return { icon: 'mdi:file-document', color: 'text-gray-500' };
+    }
+  };
+
+  const formatFileSize = (bytes) => {
+    if (bytes < 1024) return bytes + ' B';
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+    return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setErrors({});
+
+    try {
+      // Validate form data
+      await scanValidationSchema.validate(formData, { abortEarly: false });
+
+      setIsSubmitting(true);
+
+      // Create FormData for file upload
+      const formDataToSend = new FormData();
+      formDataToSend.append('title', formData.title);
+      formDataToSend.append('aiProviders', JSON.stringify(formData.aiProviders));
+      formDataToSend.append('tags', JSON.stringify(formData.tags));
+
+      // Append all documents
+      formData.documents.forEach((file) => {
+        formDataToSend.append('documents', file);
+      });
+
+      // Send to backend
+      const response = await fetch('http://localhost:3000/api/v1/scan/with-files', {
+        method: 'POST',
+        body: formDataToSend,
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || 'Failed to create scan');
+      }
+
+      const result = await response.json();
+
+      Toastify({
+        text: 'Scan created successfully!',
+        duration: 3000,
+        gravity: 'top',
+        position: 'right',
+        style: {
+          background: 'linear-gradient(to right, #00b09b, #96c93d)',
+        },
+      }).showToast();
+
+      // Call callback with result
+      if (onScanCreated) {
+        onScanCreated(result);
+      }
+
+      // Close modal
+      onClose();
+    } catch (err) {
+      if (err.name === 'ValidationError') {
+        // Yup validation errors
+        const validationErrors = {};
+        err.inner.forEach((error) => {
+          validationErrors[error.path] = error.message;
+        });
+        setErrors(validationErrors);
+      } else {
+        // API errors
+        Toastify({
+          text: err.message || 'Failed to create scan',
+          duration: 3000,
+          gravity: 'top',
+          position: 'right',
+          style: {
+            background: 'linear-gradient(to right, #ff5f6d, #ffc371)',
+          },
+        }).showToast();
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const handleBackdropClick = (event) => {
+    if (event.target === event.currentTarget && !isSubmitting) {
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6"
+      role="dialog"
+      aria-modal="true"
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-slate-900/30 backdrop-blur-sm transition-opacity"
+        onClick={handleBackdropClick}
+      ></div>
+
+      {/* Modal */}
+      <div className="relative w-full max-w-2xl transform overflow-hidden rounded-xl bg-white shadow-2xl transition-all dark:bg-slate-800">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-slate-100 px-6 py-4 dark:border-slate-700">
+          <h3 className="text-lg font-bold text-slate-900 dark:text-white">
+            Create New Scan
+          </h3>
+          <button
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="rounded-full p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-500 dark:hover:bg-slate-700 disabled:opacity-50"
+          >
+            <Icon icon="mdi:close" className="text-[20px]" />
+          </button>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} className="p-6">
+          {/* File Upload Section */}
+          <div className="mb-6">
+            <label className="mb-2 block text-sm font-bold text-slate-700 dark:text-slate-300">
+              Upload Documents
+            </label>
+            <div
+              className={`flex flex-col items-center justify-center rounded-lg border-2 border-dashed px-6 py-10 transition-colors ${
+                isDragging
+                  ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
+                  : 'border-slate-300 bg-slate-50 hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800/50'
+              } ${errors.documents ? 'border-red-500' : ''}`}
+              onDragOver={handleDragOver}
+              onDragLeave={handleDragLeave}
+              onDrop={handleDrop}
+            >
+              <div className="rounded-full bg-blue-50 p-3 dark:bg-blue-900/20">
+                <Icon
+                  icon="mdi:upload"
+                  className="text-[32px] text-blue-600 dark:text-blue-400"
+                />
+              </div>
+              <p className="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">
+                Drag &amp; drop files here or{' '}
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  className="text-blue-600 hover:underline cursor-pointer"
+                >
+                  click to browse
+                </button>
+              </p>
+              <p className="mt-1 text-xs text-slate-500">
+                Supports .txt, .pdf, .docx (max 10MB each)
+              </p>
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                accept=".pdf,.docx,.txt,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,text/plain"
+                onChange={handleFileSelect}
+                className="hidden"
+              />
+            </div>
+            {errors.documents && (
+              <p className="mt-1 text-xs text-red-600">{errors.documents}</p>
+            )}
+
+            {/* File List */}
+            {formData.documents.length > 0 && (
+              <div className="mt-4 space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Ready to upload ({formData.documents.length})
+                </p>
+                {formData.documents.map((file, index) => {
+                  const { icon, color } = getFileIcon(file);
+                  return (
+                    <div
+                      key={index}
+                      className="flex items-center justify-between rounded-md border border-slate-200 bg-white px-3 py-2 shadow-sm dark:border-slate-700 dark:bg-slate-800"
+                    >
+                      <div className="flex items-center gap-3">
+                        <Icon icon={icon} className={`text-[20px] ${color}`} />
+                        <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                          {file.name}
+                        </span>
+                        <span className="text-xs text-slate-400">
+                          {formatFileSize(file.size)}
+                        </span>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveFile(index)}
+                        className="text-slate-400 hover:text-red-500"
+                      >
+                        <Icon icon="mdi:close" className="text-[18px]" />
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          {/* Scan Configuration */}
+          <div className="mb-6 border-t border-slate-100 pt-6 dark:border-slate-700">
+            <h4 className="mb-4 text-sm font-bold uppercase tracking-wide text-slate-500">
+              Scan Configuration
+            </h4>
+
+            {/* Title Input */}
+            <div className="mb-4">
+              <label className="mb-1.5 block text-sm font-bold text-slate-700 dark:text-slate-300">
+                Scan Title
+              </label>
+              <input
+                type="text"
+                value={formData.title}
+                onChange={(e) =>
+                  setFormData((prev) => ({ ...prev, title: e.target.value }))
+                }
+                className={`block w-full rounded-lg border shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm dark:bg-slate-900 dark:text-white ${
+                  errors.title
+                    ? 'border-red-500 dark:border-red-500'
+                    : 'border-slate-300 dark:border-slate-600'
+                }`}
+                placeholder="e.g. Q4 Performance Reviews"
+              />
+              {errors.title && (
+                <p className="mt-1 text-xs text-red-600">{errors.title}</p>
+              )}
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              {/* AI Providers */}
+              <div>
+                <label className="mb-1.5 flex items-center gap-1 text-sm font-bold text-slate-700 dark:text-slate-300">
+                  <Icon icon="mdi:smart_toy" className="text-[16px]" />
+                  AI Providers
+                </label>
+                <div className="space-y-2">
+                  {AI_PROVIDERS.map((provider) => (
+                    <label
+                      key={provider.id}
+                      className="flex items-center gap-2 cursor-pointer"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={formData.aiProviders.includes(provider.id)}
+                        onChange={() => toggleAIProvider(provider.id)}
+                        className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                      />
+                      <span className="text-sm text-slate-700 dark:text-slate-300">
+                        {provider.name}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              {/* Tags */}
+              <div>
+                <label className="mb-1.5 flex items-center gap-1 text-sm font-bold text-slate-700 dark:text-slate-300">
+                  <Icon icon="mdi:tag" className="text-[16px]" />
+                  Tags
+                </label>
+                <div className="space-y-2">
+                  {AVAILABLE_TAGS.map((tag) => (
+                    <label
+                      key={tag.id}
+                      className="flex items-center gap-2 cursor-pointer"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={formData.tags.includes(tag.id)}
+                        onChange={() => toggleTag(tag.id)}
+                        className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                      />
+                      <span className="text-sm text-slate-700 dark:text-slate-300">
+                        {tag.name}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isSubmitting}
+              className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:border-slate-600 dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600 disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-bold text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isSubmitting ? 'Creating...' : 'Start Scan'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default CreateScanModal;

--- a/react-frontend/src/pages/Dashboard.jsx
+++ b/react-frontend/src/pages/Dashboard.jsx
@@ -5,6 +5,7 @@ import Toastify from 'toastify-js';
 import 'toastify-js/src/toastify.css';
 import useAuthStore from '../store/authStore';
 import Modal from '../components/Modal';
+import CreateScanModal from '../components/CreateScanModal';
 
 // Mock scan data for US-004
 const MOCK_SCANS = [
@@ -76,6 +77,7 @@ function Dashboard() {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [scanToDelete, setScanToDelete] = useState(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isCreateScanModalOpen, setIsCreateScanModalOpen] = useState(false);
 
   useEffect(() => {
     // Check if user is logged in
@@ -169,6 +171,11 @@ function Dashboard() {
     setScanToDelete(null);
   };
 
+  const handleScanCreated = (newScan) => {
+    // Add the new scan to the list
+    setScans([newScan, ...scans]);
+  };
+
   const formatDate = (date) => {
     return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
   };
@@ -247,7 +254,10 @@ function Dashboard() {
                   <Icon icon="mdi:robot" className="text-lg" />
                   <span>Manage AIs</span>
                 </button>
-                <button className="flex items-center gap-2 h-10 px-5 bg-[#6324eb] hover:bg-[#6324eb]/90 text-white rounded-lg text-sm font-bold shadow-md shadow-[#6324eb]/20 transition-colors">
+                <button 
+                  onClick={() => setIsCreateScanModalOpen(true)}
+                  className="flex items-center gap-2 h-10 px-5 bg-[#6324eb] hover:bg-[#6324eb]/90 text-white rounded-lg text-sm font-bold shadow-md shadow-[#6324eb]/20 transition-colors"
+                >
                   <Icon icon="mdi:plus" className="text-lg" />
                   <span>Create Scan</span>
                 </button>
@@ -291,7 +301,10 @@ function Dashboard() {
                   {searchQuery ? 'Try adjusting your search query' : 'Get started by creating your first scan'}
                 </p>
                 {!searchQuery && (
-                  <button className="inline-flex items-center gap-2 px-6 py-3 bg-[#6324eb] hover:bg-[#6324eb]/90 text-white rounded-lg font-bold shadow-md shadow-[#6324eb]/20 transition-colors">
+                  <button 
+                    onClick={() => setIsCreateScanModalOpen(true)}
+                    className="inline-flex items-center gap-2 px-6 py-3 bg-[#6324eb] hover:bg-[#6324eb]/90 text-white rounded-lg font-bold shadow-md shadow-[#6324eb]/20 transition-colors"
+                  >
                     <Icon icon="mdi:plus" className="text-lg" />
                     Create Your First Scan
                   </button>
@@ -415,6 +428,13 @@ function Dashboard() {
         cancelText="Cancel"
         variant="danger"
         isLoading={isDeleting}
+      />
+
+      {/* Create Scan Modal - US-010 */}
+      <CreateScanModal
+        isOpen={isCreateScanModalOpen}
+        onClose={() => setIsCreateScanModalOpen(false)}
+        onScanCreated={handleScanCreated}
       />
     </div>
   );

--- a/react-frontend/src/tests/CreateScanModal.test.jsx
+++ b/react-frontend/src/tests/CreateScanModal.test.jsx
@@ -1,0 +1,453 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CreateScanModal from '../components/CreateScanModal';
+
+// Mock Toastify
+vi.mock('toastify-js', () => ({
+  default: vi.fn(() => ({
+    showToast: vi.fn(),
+  })),
+}));
+
+describe('CreateScanModal', () => {
+  const mockOnClose = vi.fn();
+  const mockOnScanCreated = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  it('should render modal when isOpen is true', () => {
+    render(
+      <CreateScanModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onScanCreated={mockOnScanCreated}
+      />
+    );
+
+    expect(screen.getByText('Create New Scan')).toBeInTheDocument();
+    expect(screen.getByText('Upload Documents')).toBeInTheDocument();
+    expect(screen.getByText('Scan Configuration')).toBeInTheDocument();
+  });
+
+  it('should not render modal when isOpen is false', () => {
+    render(
+      <CreateScanModal
+        isOpen={false}
+        onClose={mockOnClose}
+        onScanCreated={mockOnScanCreated}
+      />
+    );
+
+    expect(screen.queryByText('Create New Scan')).not.toBeInTheDocument();
+  });
+
+  it('should show validation error when title is empty', async () => {
+    render(
+      <CreateScanModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onScanCreated={mockOnScanCreated}
+      />
+    );
+
+    const submitButton = screen.getByText('Start Scan');
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/title is required|title must be at least 3 characters/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('should show validation error when no documents are uploaded', async () => {
+    render(
+      <CreateScanModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onScanCreated={mockOnScanCreated}
+      />
+    );
+
+    const titleInput = screen.getByPlaceholderText('e.g. Q4 Performance Reviews');
+    fireEvent.change(titleInput, { target: { value: 'Test Scan' } });
+
+    const submitButton = screen.getByText('Start Scan');
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('At least one document is required')).toBeInTheDocument();
+    });
+  });
+
+  it('should validate file type - reject invalid file types', async () => {
+    render(
+      <CreateScanModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onScanCreated={mockOnScanCreated}
+      />
+    );
+
+    const titleInput = screen.getByPlaceholderText('e.g. Q4 Performance Reviews');
+    fireEvent.change(titleInput, { target: { value: 'Test Scan' } });
+
+    // Create a mock file with invalid type
+    const invalidFile = new File(['test content'], 'test.jpg', { type: 'image/jpeg' });
+    const fileInput = document.querySelector('input[type="file"]');
+
+    Object.defineProperty(fileInput, 'files', {
+      value: [invalidFile],
+      writable: false,
+    });
+
+    fireEvent.change(fileInput);
+
+    const submitButton = screen.getByText('Start Scan');
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Only PDF, DOCX, and TXT files are allowed')).toBeInTheDocument();
+    });
+  });
+
+  it('should validate file size - reject files over 10MB', async () => {
+    render(
+      <CreateScanModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onScanCreated={mockOnScanCreated}
+      />
+    );
+
+    const titleInput = screen.getByPlaceholderText('e.g. Q4 Performance Reviews');
+    fireEvent.change(titleInput, { target: { value: 'Test Scan' } });
+
+    // Create a mock file that's too large (11MB)
+    const largeFile = new File(['x'.repeat(11 * 1024 * 1024)], 'large.pdf', {
+      type: 'application/pdf',
+    });
+    
+    // Mock the size property
+    Object.defineProperty(largeFile, 'size', {
+      value: 11 * 1024 * 1024,
+      writable: false,
+    });
+
+    const fileInput = document.querySelector('input[type="file"]');
+
+    Object.defineProperty(fileInput, 'files', {
+      value: [largeFile],
+      writable: false,
+    });
+
+    fireEvent.change(fileInput);
+
+    const submitButton = screen.getByText('Start Scan');
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Each file must be less than 10MB')).toBeInTheDocument();
+    });
+  });
+
+  it('should accept valid PDF file', async () => {
+    render(
+      <CreateScanModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onScanCreated={mockOnScanCreated}
+      />
+    );
+
+    const titleInput = screen.getByPlaceholderText('e.g. Q4 Performance Reviews');
+    fireEvent.change(titleInput, { target: { value: 'Test Scan' } });
+
+    // Create a valid PDF file
+    const validFile = new File(['pdf content'], 'test.pdf', { type: 'application/pdf' });
+    Object.defineProperty(validFile, 'size', {
+      value: 1024 * 1024, // 1MB
+      writable: false,
+    });
+
+    const fileInput = document.querySelector('input[type="file"]');
+
+    Object.defineProperty(fileInput, 'files', {
+      value: [validFile],
+      writable: false,
+    });
+
+    fireEvent.change(fileInput);
+
+    await waitFor(() => {
+      expect(screen.getByText('test.pdf')).toBeInTheDocument();
+      expect(screen.getByText('Ready to upload (1)')).toBeInTheDocument();
+    });
+  });
+
+  it('should accept valid DOCX file', async () => {
+    render(
+      <CreateScanModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onScanCreated={mockOnScanCreated}
+      />
+    );
+
+    const validFile = new File(['docx content'], 'test.docx', {
+      type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    });
+    Object.defineProperty(validFile, 'size', {
+      value: 1024 * 1024, // 1MB
+      writable: false,
+    });
+
+    const fileInput = document.querySelector('input[type="file"]');
+
+    Object.defineProperty(fileInput, 'files', {
+      value: [validFile],
+      writable: false,
+    });
+
+    fireEvent.change(fileInput);
+
+    await waitFor(() => {
+      expect(screen.getByText('test.docx')).toBeInTheDocument();
+    });
+  });
+
+  it('should accept valid TXT file', async () => {
+    render(
+      <CreateScanModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onScanCreated={mockOnScanCreated}
+      />
+    );
+
+    const validFile = new File(['text content'], 'test.txt', {
+      type: 'text/plain',
+    });
+    Object.defineProperty(validFile, 'size', {
+      value: 1024, // 1KB
+      writable: false,
+    });
+
+    const fileInput = document.querySelector('input[type="file"]');
+
+    Object.defineProperty(fileInput, 'files', {
+      value: [validFile],
+      writable: false,
+    });
+
+    fireEvent.change(fileInput);
+
+    await waitFor(() => {
+      expect(screen.getByText('test.txt')).toBeInTheDocument();
+    });
+  });
+
+  it('should allow removing uploaded files', async () => {
+    render(
+      <CreateScanModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onScanCreated={mockOnScanCreated}
+      />
+    );
+
+    const validFile = new File(['content'], 'test.pdf', { type: 'application/pdf' });
+    Object.defineProperty(validFile, 'size', {
+      value: 1024,
+      writable: false,
+    });
+
+    const fileInput = document.querySelector('input[type="file"]');
+    Object.defineProperty(fileInput, 'files', {
+      value: [validFile],
+      writable: false,
+    });
+
+    fireEvent.change(fileInput);
+
+    await waitFor(() => {
+      expect(screen.getByText('test.pdf')).toBeInTheDocument();
+    });
+
+    // Find and click the remove button
+    const removeButtons = screen.getAllByRole('button');
+    const removeButton = removeButtons.find(
+      (btn) => btn.querySelector('[class*="mdi:close"]')
+    );
+
+    if (removeButton) {
+      fireEvent.click(removeButton);
+
+      await waitFor(() => {
+        expect(screen.queryByText('test.pdf')).not.toBeInTheDocument();
+      });
+    }
+  });
+
+  it('should allow selecting AI providers', () => {
+    render(
+      <CreateScanModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onScanCreated={mockOnScanCreated}
+      />
+    );
+
+    const gpt4Label = screen.getByLabelText(/GPT-4/i);
+    const gpt4Checkbox = gpt4Label.querySelector('input[type="checkbox"]') || gpt4Label;
+    fireEvent.click(gpt4Checkbox);
+
+    expect(gpt4Checkbox.checked).toBe(true);
+  });
+
+  it('should allow selecting tags', () => {
+    render(
+      <CreateScanModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onScanCreated={mockOnScanCreated}
+      />
+    );
+
+    const academicLabel = screen.getByLabelText(/Academic/i);
+    const academicCheckbox = academicLabel.querySelector('input[type="checkbox"]') || academicLabel;
+    fireEvent.click(academicCheckbox);
+
+    expect(academicCheckbox.checked).toBe(true);
+  });
+
+  it('should close modal when Cancel button is clicked', () => {
+    render(
+      <CreateScanModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onScanCreated={mockOnScanCreated}
+      />
+    );
+
+    const cancelButton = screen.getByText('Cancel');
+    fireEvent.click(cancelButton);
+
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it('should submit form with valid data', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ id: 1, title: 'Test Scan' }),
+      })
+    );
+
+    render(
+      <CreateScanModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onScanCreated={mockOnScanCreated}
+      />
+    );
+
+    // Fill in title
+    const titleInput = screen.getByPlaceholderText('e.g. Q4 Performance Reviews');
+    fireEvent.change(titleInput, { target: { value: 'Test Scan' } });
+
+    // Add a file
+    const validFile = new File(['content'], 'test.pdf', { type: 'application/pdf' });
+    Object.defineProperty(validFile, 'size', {
+      value: 1024,
+      writable: false,
+    });
+
+    const fileInput = document.querySelector('input[type="file"]');
+    Object.defineProperty(fileInput, 'files', {
+      value: [validFile],
+      writable: false,
+    });
+
+    fireEvent.change(fileInput);
+
+    // Select an AI provider
+    const gpt4Label = screen.getByLabelText(/GPT-4/i);
+    const gpt4Checkbox = gpt4Label.querySelector('input[type="checkbox"]') || gpt4Label;
+    fireEvent.click(gpt4Checkbox);
+
+    // Select a tag
+    const academicLabel = screen.getByLabelText(/Academic/i);
+    const academicCheckbox = academicLabel.querySelector('input[type="checkbox"]') || academicLabel;
+    fireEvent.click(academicCheckbox);
+
+    // Submit the form
+    const submitButton = screen.getByText('Start Scan');
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/scan/with-files',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.any(FormData),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockOnScanCreated).toHaveBeenCalledWith({ id: 1, title: 'Test Scan' });
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+  });
+
+  it('should handle API errors gracefully', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve({ message: 'Server error' }),
+      })
+    );
+
+    render(
+      <CreateScanModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onScanCreated={mockOnScanCreated}
+      />
+    );
+
+    // Fill in title
+    const titleInput = screen.getByPlaceholderText('e.g. Q4 Performance Reviews');
+    fireEvent.change(titleInput, { target: { value: 'Test Scan' } });
+
+    // Add a file
+    const validFile = new File(['content'], 'test.pdf', { type: 'application/pdf' });
+    Object.defineProperty(validFile, 'size', {
+      value: 1024,
+      writable: false,
+    });
+
+    const fileInput = document.querySelector('input[type="file"]');
+    Object.defineProperty(fileInput, 'files', {
+      value: [validFile],
+      writable: false,
+    });
+
+    fireEvent.change(fileInput);
+
+    // Submit the form
+    const submitButton = screen.getByText('Start Scan');
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+      expect(mockOnScanCreated).not.toHaveBeenCalled();
+      expect(mockOnClose).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces support for uploading and associating documents with scans in the backend, and integrates a modal for creating scans in the frontend dashboard. The backend changes include new database schema and API endpoints for handling file uploads, while the frontend now allows users to trigger scan creation via a modal. Below are the most important changes grouped by theme:

**Backend: Document Upload and Association**

* Added a new `Document` model and table to the database, including migration and schema updates, to store metadata for uploaded files and associate them with scans. (`nest-backend/prisma/schema.prisma`, `nest-backend/prisma/migrations/20260211222347_add_documents_table/migration.sql`) [[1]](diffhunk://#diff-f131c37e678c430fa5d205c00c62ff279e157bcd29e5e5c4bd8e9496ff773a05R28-R44) [[2]](diffhunk://#diff-5df55dba20c04df2887631264010d647e7b15137c1ac965b686fdd4c46c92527R1-R16)
* Implemented a new endpoint `POST /api/v1/scan/with-files` in `ScanController` that handles file uploads (PDF, DOCX, TXT), validates input, and associates uploaded documents with the created scan. (`nest-backend/src/scan/scan.controller.ts`)
* Updated `ScanService` to support creating scans with associated documents and tags, and to return documents when fetching scans. (`nest-backend/src/scan/scan.service.ts`)
* Added `CreateScanWithFilesDto` for validating scan creation requests with files. (`nest-backend/src/scan/dto/create-scan.dto.ts`)
* Added `@types/multer` to dependencies for type safety in file upload handling. (`nest-backend/package.json`, `nest-backend/pnpm-lock.yaml`) [[1]](diffhunk://#diff-ad4d6133baea77082868d37edff66faf197324ec569633ace38b4d9f5e95efbfR56) [[2]](diffhunk://#diff-8d6d01aaf961e94822d756d22af61fab66a3b2d7ae2d2ea06a822d64173b531aR102-R104) [[3]](diffhunk://#diff-8d6d01aaf961e94822d756d22af61fab66a3b2d7ae2d2ea06a822d64173b531aR1079-R1081) [[4]](diffhunk://#diff-8d6d01aaf961e94822d756d22af61fab66a3b2d7ae2d2ea06a822d64173b531aR4823-R4826)

**Frontend: Scan Creation Modal Integration**

* Integrated a `CreateScanModal` component into the Dashboard, allowing users to open the modal and create new scans, which are then added to the scan list upon creation. (`react-frontend/src/pages/Dashboard.jsx`) [[1]](diffhunk://#diff-bb762301ac761a72305442eb8f399077dd8d2289c6467de506ef8f63bb0882acR8) [[2]](diffhunk://#diff-bb762301ac761a72305442eb8f399077dd8d2289c6467de506ef8f63bb0882acR80) [[3]](diffhunk://#diff-bb762301ac761a72305442eb8f399077dd8d2289c6467de506ef8f63bb0882acR174-R178) [[4]](diffhunk://#diff-bb762301ac761a72305442eb8f399077dd8d2289c6467de506ef8f63bb0882acL250-R260) [[5]](diffhunk://#diff-bb762301ac761a72305442eb8f399077dd8d2289c6467de506ef8f63bb0882acL294-R307) [[6]](diffhunk://#diff-bb762301ac761a72305442eb8f399077dd8d2289c6467de506ef8f63bb0882acR432-R438)

Closes #17 